### PR TITLE
Fix __set_FPSCR not working bug

### DIFF
--- a/bee/rtl87x2g/boot/inc/vector_table.h
+++ b/bee/rtl87x2g/boot/inc/vector_table.h
@@ -7,7 +7,6 @@ extern "C" {
 
 #include "stdint.h"
 #include "stdbool.h"
-#include "cmsis_compiler.h"
 #include "vector_table_auto_gen.h"
 
 /** @defgroup VECTOR_TABLE  Vector table


### PR DESCRIPTION
cmsis_compiler.h should be include in the core_cm55.h after the __FPU_USED has been defined.
cmsis_compiler.h cannot be include before the core_cm55.h.