### PR TITLE
rtl87x2g: add pad_short_pulse_wake_up rom symbol

### DIFF
--- a/bee/drivers/i2c/src/rtl87x2g/rtl87x2g_i2c.c
+++ b/bee/drivers/i2c/src/rtl87x2g/rtl87x2g_i2c.c
@@ -206,7 +206,7 @@ void I2C_DLPSExit(void *PeriReg, void *StoreBuf)
 
     I2Cx->IC_INTR_MASK   = store_buf->i2c_reg[8];
     I2Cx->IC_RX_TL       = store_buf->i2c_reg[9];
-    I2Cx->IC_RX_TL       = store_buf->i2c_reg[10];
+    I2Cx->IC_TX_TL       = store_buf->i2c_reg[10];
     I2Cx->IC_ENABLE      = store_buf->i2c_reg[11];
     I2Cx->IC_SDA_HOLD    = store_buf->i2c_reg[12];
     I2Cx->IC_SLV_DATA_NACK_ONLY = store_buf->i2c_reg[13];

--- a/bee/rtl87x2g/boot/lib/libROM.a
+++ b/bee/rtl87x2g/boot/lib/libROM.a
@@ -169,3 +169,4 @@ platform_rtc_get_counter = 0x0014f340 ;
 flash_nor_ioctl_buf = 0x0014f40c ;
 flash_nor_ioctl_buf_len = 0x0014f410 ;
 secure_app_num = 0x0014fc28 ;
+pad_short_pulse_wake_up = 0x0001c289;


### PR DESCRIPTION
1.add pad_short_pulse_wake_upto support short pulse pad wakeup; 2.correct i2c restore flow;