### PR TITLE
osif: replace k_uptime_ticks() with sys_clock_tick_get_32()

### DIFF
--- a/bee/rtl8752h/osif/zephyr/osif_zephyr.c
+++ b/bee/rtl8752h/osif/zephyr/osif_zephyr.c
@@ -398,14 +398,13 @@ bool os_delay_zephyr(uint32_t ms)
 
 bool os_sys_time_get_zephyr(uint64_t *p_time_ms)
 {
-    *p_time_ms = k_uptime_get();
+    *p_time_ms = (uint64_t)k_ticks_to_ms_floor64(sys_clock_tick_get_32());
     return true;
 }
 
 bool os_sys_tick_get_zephyr(uint64_t *p_sys_tick)
 {
-    *p_sys_tick = (uint64_t)k_uptime_ticks();
-
+    *p_sys_tick = (uint64_t)sys_clock_tick_get_32();
     return true;
 }
 
@@ -1361,8 +1360,6 @@ uint32_t os_sys_tick_clk_get_zephyr(void)
 
 void os_task_dlps_return_idle_task_zephyr(void)
 {
-    DBG_DIRECT("%s is called", __func__);
-
     arch_kernel_init();//perform arm initialization: including fault exception init & msp setting.
 
     NVIC_SetPriority(PendSV_IRQn, 0xff);

--- a/bee/rtl87x2g/osif/zephyr/osif_zephyr.c
+++ b/bee/rtl87x2g/osif/zephyr/osif_zephyr.c
@@ -119,12 +119,12 @@ void os_delay_zephyr(uint32_t ms)
 
 uint64_t os_sys_time_get_zephyr(void)
 {
-    return (uint64_t)k_uptime_get();
+    return (uint64_t)k_ticks_to_ms_floor64(sys_clock_tick_get_32());
 }
 
 uint64_t os_sys_tick_get_zephyr(void)
 {
-    return (uint64_t)k_uptime_ticks();
+    return (uint64_t)sys_clock_tick_get_32();
 }
 
 


### PR DESCRIPTION
Problem
-------
The SysTick ISR already holds timeout_lock.
If it is pre-empted by the BTMAC NMI, the NMI path calls log_buffer() → k_uptime_ticks(), which tries to take the same timeout_lock again, causing a recursive spin-lock scenario that triggers a hang on RTL8752H.

Solution
--------
In the SysTick ISR we only need the current tick count; we do not need to enter the timeout subsystem.  Replace k_uptime_ticks() with the lock-free sys_clock_tick_get_32() helper to avoid taking timeout_lock.

Impact
------
• Removes the possibility of recursive spin-lock deadlock when NMI
  pre-empts SysTick.
  • No functional change to tick calculation accuracy.
  • Verified on RTL8752H: continuous log_buffer() in NMI no longer hangs
    the system; observed tick values are correct.