### PR TITLE
rtl8752h: fix flash_sem issue in libROM

### DIFF
--- a/bee/rtl8752h/boot/lib/libROM.a
+++ b/bee/rtl8752h/boot/lib/libROM.a
@@ -437,7 +437,6 @@ altrac_fb_alg_setting = 0x00200f64 ;
 sdm_setting = 0x00200f74 ;
 platform_pm_feature_cfg = 0x00200f80 ;
 efuse_on_ram = 0x00200f81 ;
-flash_sem = 0x0020137c ;
 flash_nor_info = 0x00201394 ;
 flash_sleep_enter = 0x00201424 ;
 flash_sleep_exit = 0x00201428 ;

--- a/bee/rtl8752h/boot/lib/libROM_plus.a
+++ b/bee/rtl8752h/boot/lib/libROM_plus.a
@@ -27,3 +27,4 @@ si_flow_after_exit_low_power_mode = 0x00200900;
 si_flow_after_power_on_sequence_restart = 0x002008f8;
 si_flow_data_init = 0x002008f0;
 thermal_meter_read = 0x00200ce0 ;
+flash_sem_init = 0x000010af ;


### PR DESCRIPTION
1. Remove the flash_sem symbol from the library to prevent redefinition conflicts.
2. Add the flash_sem_init symbol to the library for initialization within the flash driver.