### PR TITLE
osif: support delete itself in os_task_delete

### DIFF
--- a/bee/rtl8752h/osif/zephyr/osif_zephyr.c
+++ b/bee/rtl8752h/osif/zephyr/osif_zephyr.c
@@ -715,6 +715,11 @@ bool os_task_delete_zephyr(void *p_handle, bool *p_result)
 
     obj = (struct k_thread *)p_handle;
 
+    if (obj == NULL)
+    {
+        k_thread_abort(_current);
+    }
+
     k_thread_abort(obj);
 
     *p_result = true;

--- a/bee/rtl87x2g/osif/zephyr/osif_zephyr.c
+++ b/bee/rtl87x2g/osif/zephyr/osif_zephyr.c
@@ -300,6 +300,11 @@ bool os_task_delete_zephyr(void *p_handle)
 
     obj = (struct k_thread *)p_handle;
 
+    if (obj == NULL)
+    {
+        k_thread_abort(_current);
+    }
+
     k_thread_abort(obj);
     //task signal todo
     return true;


### PR DESCRIPTION
1. when the input is NULL in os_task_delete, delete its own task.