### PR TITLE
drivers: remove zephyr_library() to reduce build path length

### DIFF
--- a/bee/drivers/adc/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/adc/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_adc.c)
 
 zephyr_link_libraries(${CMAKE_CURRENT_SOURCE_DIR}/libadc.a)

--- a/bee/drivers/adc/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/adc/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_ADC rtl87x2g_adc.c)

--- a/bee/drivers/adc/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/adc/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_ADC rtl_adc.c)

--- a/bee/drivers/bluetooth/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/bluetooth/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_bt_hci.c)

--- a/bee/drivers/can/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/can/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2025 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_link_libraries(${CMAKE_CURRENT_SOURCE_DIR}/librtl87x2g_can.a)

--- a/bee/drivers/codec/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/codec/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_codec.c)

--- a/bee/drivers/codec/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/codec/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_codec.c)

--- a/bee/drivers/dma/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/dma/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_gdma.c)

--- a/bee/drivers/dma/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/dma/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_gdma.c)

--- a/bee/drivers/dma/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/dma/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_gdma.c)

--- a/bee/drivers/gpio/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/gpio/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_gpio.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/gpio/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/gpio/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_gpio.c)

--- a/bee/drivers/gpio/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/gpio/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_gpio.c)

--- a/bee/drivers/i2c/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/i2c/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_i2c.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/i2c/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/i2c/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_i2c.c)

--- a/bee/drivers/i2c/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/i2c/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_i2c.c)

--- a/bee/drivers/i2s/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/i2s/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_i2s.c)

--- a/bee/drivers/i2s/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/i2s/src/rtl87x2g/CMakeLists.txt
@@ -1,4 +1,2 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
-
-zephyr_library()

--- a/bee/drivers/i2s/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/i2s/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_i2s.c)

--- a/bee/drivers/ir/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/ir/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_ir.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/ir/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/ir/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_ir.c)

--- a/bee/drivers/ir/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/ir/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_ir.c)

--- a/bee/drivers/keyscan/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/keyscan/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_keyscan.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/keyscan/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/keyscan/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_keyscan.c)

--- a/bee/drivers/keyscan/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/keyscan/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_keyscan.c)

--- a/bee/drivers/nvic/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/nvic/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_nvic.c)

--- a/bee/drivers/nvic/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/nvic/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_nvic.c)

--- a/bee/drivers/pinmux/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/pinmux/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_pinmux.c)

--- a/bee/drivers/pinmux/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/pinmux/src/rtl87x2g/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_pinmux.c)
 zephyr_code_relocate(FILES rtl_pinmux.c LOCATION ITCM)

--- a/bee/drivers/qdec/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/qdec/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2025 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_qdec.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/qdec/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/qdec/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_AON_QDEC rtl_aon_qdec.c)

--- a/bee/drivers/rcc/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/rcc/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_rcc.c)

--- a/bee/drivers/rcc/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/rcc/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_rcc.c)

--- a/bee/drivers/rtc/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/rtc/src/rtl8752h/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_rtc.c)

--- a/bee/drivers/rtc/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/rtc/src/rtl87x2g/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
-zephyr_library()
 
 zephyr_library_sources(rtl87x2g_rtc.c)

--- a/bee/drivers/rtc/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/rtc/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_rtc.c)

--- a/bee/drivers/sdhc/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/sdhc/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_link_libraries(${CMAKE_CURRENT_SOURCE_DIR}/libsd.a)

--- a/bee/drivers/spi/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/spi/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_spi.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/spi/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/spi/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_spi.c)

--- a/bee/drivers/spi/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/spi/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_spi.c)

--- a/bee/drivers/spi3w/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/spi3w/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_3wire_spi.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/spi3w/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/spi3w/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_spi3w.c)

--- a/bee/drivers/spi3w/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/spi3w/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_spi3w.c)

--- a/bee/drivers/tim/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/tim/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 if(CONFIG_REALTEK_TIM)
 zephyr_library_sources(rtl876x_tim.c)
 endif()

--- a/bee/drivers/tim/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/tim/src/rtl87x2g/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_TIM rtl87x2g_tim.c)
 zephyr_library_sources_ifdef(CONFIG_REALTEK_ENHTIM rtl87x2g_enh_tim.c)

--- a/bee/drivers/tim/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/tim/src/rtl_common/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_TIM rtl_tim.c)
 zephyr_library_sources_ifdef(CONFIG_REALTEK_ENHTIM rtl_enh_tim.c)

--- a/bee/drivers/uart/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/uart/src/rtl8752h/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl876x_uart.c)
 
 if (CONFIG_PM_DEVICE)

--- a/bee/drivers/uart/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/uart/src/rtl87x2g/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl87x2g_uart.c)

--- a/bee/drivers/uart/src/rtl_common/CMakeLists.txt
+++ b/bee/drivers/uart/src/rtl_common/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(rtl_uart.c)

--- a/bee/drivers/wdt/src/rtl8752h/CMakeLists.txt
+++ b/bee/drivers/wdt/src/rtl8752h/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_AON_WDT rtl876x_aon_wdg.c)
 zephyr_library_sources_ifdef(CONFIG_REALTEK_CORE_WDT rtl876x_wdg.c)

--- a/bee/drivers/wdt/src/rtl87x2g/CMakeLists.txt
+++ b/bee/drivers/wdt/src/rtl87x2g/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_REALTEK_AON_WDT rtl87x2g_aon_wdt.c)
 zephyr_library_sources_ifdef(CONFIG_REALTEK_CORE_WDT rtl87x2g_wdt.c)

--- a/bee/rtl8752h/osif/zephyr/CMakeLists.txt
+++ b/bee/rtl8752h/osif/zephyr/CMakeLists.txt
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
 zephyr_library_sources(osif_zephyr.c)
 zephyr_include_directories(${ZEPHYR_BASE}/arch/arm/include) # arch_kernel_init
 zephyr_include_directories(${ZEPHYR_BASE}/kernel/include) # z_idle_threads

--- a/bee/rtl87x2g/osif/zephyr/CMakeLists.txt
+++ b/bee/rtl87x2g/osif/zephyr/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) 2024 Realtek Semiconductor Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
 zephyr_library_sources(osif_zephyr.c)
 zephyr_code_relocate(FILES osif_zephyr.c LOCATION ITCM)
 zephyr_include_directories(${ZEPHYR_BASE}/arch/arm/include) # arch_kernel_init


### PR DESCRIPTION
Remove zephyr_library() to reduce build path length.